### PR TITLE
Object reader writer refactorization

### DIFF
--- a/Migrant/Generators/ReadMethodGenerator.cs
+++ b/Migrant/Generators/ReadMethodGenerator.cs
@@ -967,7 +967,8 @@ namespace Antmicro.Migrant.Generators
             // method returns read type (or null) 
 
             generator.Emit(OpCodes.Ldarg_0); // object reader
-            generator.Emit(OpCodes.Call, Helpers.GetMethodInfo<ObjectReader, TypeDescriptor>(or => or.ReadType()));
+            generator.Emit(OpCodes.Call, Helpers.GetPropertyGetterInfo<ObjectReader, IdentifiedElementsList<TypeDescriptor>>(or => or.Types));
+            generator.Emit(OpCodes.Call, Helpers.GetMethodInfo<IdentifiedElementsList<TypeDescriptor>, TypeDescriptor>(t => t.Read()));
             generator.Emit(OpCodes.Call, Helpers.GetPropertyGetterInfo<TypeDescriptor, Type>(td => td.UnderlyingType));
         }
 

--- a/Migrant/Generators/ReadMethodGenerator.cs
+++ b/Migrant/Generators/ReadMethodGenerator.cs
@@ -36,6 +36,7 @@ using Antmicro.Migrant.Hooks;
 using Antmicro.Migrant.Utilities;
 using System.Collections;
 using Antmicro.Migrant.Generators;
+using Antmicro.Migrant.VersionTolerance;
 
 namespace Antmicro.Migrant.Generators
 {
@@ -975,7 +976,9 @@ namespace Antmicro.Migrant.Generators
             // method returns read methodInfo (or null)
 
             generator.Emit(OpCodes.Ldarg_0); // object reader
-            generator.Emit(OpCodes.Call, Helpers.GetMethodInfo<ObjectReader, MethodInfo>(or => or.ReadMethod()));
+            generator.Emit(OpCodes.Call, Helpers.GetPropertyGetterInfo<ObjectReader, IdentifiedElementsList<MethodDescriptor>>(or => or.Methods));
+            generator.Emit(OpCodes.Call, Helpers.GetMethodInfo<IdentifiedElementsList<MethodDescriptor>, MethodDescriptor>(or => or.Read()));
+            generator.Emit(OpCodes.Call, Helpers.GetPropertyGetterInfo<MethodDescriptor, MethodInfo>(md => md.UnderlyingMethod));
         }
 
         public DynamicMethod Method

--- a/Migrant/Generators/ReadMethodGenerator.cs
+++ b/Migrant/Generators/ReadMethodGenerator.cs
@@ -753,7 +753,7 @@ namespace Antmicro.Migrant.Generators
 
         private void GenerateUpdateFields(Type formalType, LocalBuilder objectIdLocal)
         {
-            var fields = TypeDescriptor.CreateFromType(formalType).FieldsToDeserialize;
+            var fields = ((TypeDescriptor)formalType).FieldsToDeserialize;
             foreach(var fieldOrType in fields)
             {
                 if(fieldOrType.Field == null)
@@ -793,7 +793,7 @@ namespace Antmicro.Migrant.Generators
 
         private void GenerateUpdateStructFields(Type formalType, LocalBuilder structLocal)
         {			
-            var fields = TypeDescriptor.CreateFromType(formalType).FieldsToDeserialize;
+            var fields = ((TypeDescriptor)formalType).FieldsToDeserialize;
             foreach(var field in fields)
             {
                 if(field.Field == null)

--- a/Migrant/Helpers.cs
+++ b/Migrant/Helpers.cs
@@ -166,7 +166,7 @@ namespace Antmicro.Migrant
                 return null;
             }
 
-            return pinfo.GetGetMethod();
+            return pinfo.GetGetMethod(true);
         }
 
         public static MethodInfo GetMethodInfo(Expression<Action> expression)

--- a/Migrant/Helpers.cs
+++ b/Migrant/Helpers.cs
@@ -186,6 +186,11 @@ namespace Antmicro.Migrant
             return methodCall.Method;
         }
 
+        public static MethodInfo GetImplicitConvertionOperatorInfo<TTo, TFrom>()
+        {
+            return typeof(TFrom).GetMethods(BindingFlags.Public | BindingFlags.Static).Single(x => x.Name == "op_Implicit" && x.GetParameters().Count() == 1 && x.GetParameters().ElementAt(0).ParameterType == typeof(TTo));
+        }
+
         public static MethodInfo GetMethodInfo<T>(Expression<Action<T>> expression)
         {
             var methodCall = (MethodCallExpression)expression.Body;
@@ -196,6 +201,11 @@ namespace Antmicro.Migrant
         {
             var methodCall = (MethodCallExpression)expression.Body;
             return methodCall.Method;
+        }
+
+        public static ConstructorInfo GetConstructorInfo<T>(params Type[] argumentsTypes)
+        {
+            return typeof(T).GetConstructor(argumentsTypes);
         }
 
         public static bool IsWriteableByPrimitiveWriter(Type type)

--- a/Migrant/Migrant.csproj
+++ b/Migrant/Migrant.csproj
@@ -79,6 +79,9 @@
     <Compile Include="VersionTolerance\AssemblyDescriptor.cs" />
     <Compile Include="VersionTolerance\VersionToleranceException.cs" />
     <Compile Include="VersionTolerance\ModuleDescriptor.cs" />
+    <Compile Include="Utilities\IdentifiedElementsList.cs" />
+    <Compile Include="Utilities\IIdentifiedElement.cs" />
+    <Compile Include="VersionTolerance\MethodDescriptor.cs" />
     <Compile Include="TypeOrGenericTypeArgument.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />

--- a/Migrant/Migrant.csproj
+++ b/Migrant/Migrant.csproj
@@ -83,6 +83,7 @@
     <Compile Include="Utilities\IIdentifiedElement.cs" />
     <Compile Include="VersionTolerance\MethodDescriptor.cs" />
     <Compile Include="TypeOrGenericTypeArgument.cs" />
+    <Compile Include="Utilities\IdentifiedElementsDictionary.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Migrant/Migrant.csproj
+++ b/Migrant/Migrant.csproj
@@ -79,6 +79,7 @@
     <Compile Include="VersionTolerance\AssemblyDescriptor.cs" />
     <Compile Include="VersionTolerance\VersionToleranceException.cs" />
     <Compile Include="VersionTolerance\ModuleDescriptor.cs" />
+    <Compile Include="TypeOrGenericTypeArgument.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
   <ItemGroup>

--- a/Migrant/ObjectReader.cs
+++ b/Migrant/ObjectReader.cs
@@ -95,9 +95,9 @@ namespace Antmicro.Migrant
             this.readMethodsCache = readMethods ?? new Dictionary<Type, DynamicMethod>();
             this.useGeneratedDeserialization = isGenerating;
             typeCache = new Dictionary<int, TypeDescriptor>();
-            methodList = new List<MethodInfo>();
-            assembliesList = new List<AssemblyDescriptor>();
-            modulesList = new List<ModuleDescriptor>();
+            Methods = new IdentifiedElementsList<MethodDescriptor>(this);
+            Assemblies = new IdentifiedElementsList<AssemblyDescriptor>(this);
+            Modules = new IdentifiedElementsList<ModuleDescriptor>(this);
             postDeserializationHooks = new List<Action>();
             this.postDeserializationCallback = postDeserializationCallback;
             this.treatCollectionAsUserObject = treatCollectionAsUserObject;
@@ -500,8 +500,8 @@ namespace Antmicro.Migrant
             for(var i = 0; i < invocationListLength; i++)
             {
                 var target = ReadField(typeof(object));
-                var method = ReadMethod();
-                var del = Delegate.CreateDelegate(type, target, method);
+                var method = Methods.Read();
+                var del = Delegate.CreateDelegate(type, target, method.UnderlyingMethod);
                 deserializedObjects[objectId] = Delegate.Combine((Delegate)deserializedObjects[objectId], del);
             }
         }
@@ -574,94 +574,6 @@ namespace Antmicro.Migrant
             return type;
         }
 
-        internal MethodInfo ReadMethod()
-        {
-            MethodInfo result = null;
-
-            var methodId = reader.ReadInt32();
-            if(methodList.Count <= methodId)
-            {
-                var type = ReadType().UnderlyingType;
-                var methodName = reader.ReadString();
-                var genericArgumentsCount = reader.ReadInt32();
-                var genericArguments = new Type[genericArgumentsCount];
-                for(int i = 0; i < genericArgumentsCount; i++)
-                {
-                    genericArguments[i] = ReadType().UnderlyingType;
-                }
-
-                var parametersCount = reader.ReadInt32();
-                if(genericArgumentsCount > 0)
-                {
-                    var parameters = new TypeOrGenericTypeArgument[parametersCount];
-                    for(int i = 0; i < parameters.Length; i++)
-                    {
-                        var genericType = reader.ReadBoolean();
-                        parameters[i] = genericType ? 
-                            new TypeOrGenericTypeArgument(reader.ReadInt32()) :
-                            new TypeOrGenericTypeArgument(ReadType().UnderlyingType);
-                    }
-
-                    result = type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic).SingleOrDefault(m => 
-                        m.IsGenericMethod && 
-                        m.GetGenericMethodDefinition().Name == methodName && 
-                        m.GetGenericArguments().Length == genericArgumentsCount && 
-                        CompareGenericArguments(m.GetGenericMethodDefinition().GetParameters(), parameters));
-
-                    if(result != null)
-                    {
-                        result = result.MakeGenericMethod(genericArguments);
-                    }
-                }
-                else
-                {
-                    var types = new Type[parametersCount];
-                    for(int i = 0; i < types.Length; i++)
-                    {
-                        types[i] = ReadType().UnderlyingType;
-                    }
-
-                    result = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, types, null);
-                }
-
-                methodList.Add(result);
-            }
-            else
-            {
-                result = methodList[methodId];
-            }
-
-            return result;
-        }
-
-        internal AssemblyDescriptor ReadAssembly()
-        {
-            var assemblyId = PrimitiveReader.ReadInt32();
-            if(assembliesList.Count <= assemblyId)
-            {
-                var descriptor = AssemblyDescriptor.ReadFromStream(this);
-                assembliesList.Add(descriptor);
-                return descriptor;
-            }
-            else
-            {
-                return assembliesList[assemblyId];
-            }
-        }
-
-        internal ModuleDescriptor ReadModule()
-        {
-            var moduleId = PrimitiveReader.ReadInt32();
-            if(modulesList.Count <= moduleId)
-            {
-                var descriptor = ModuleDescriptor.ReadFromStream(this);
-                modulesList.Add(descriptor);
-                return descriptor;
-            }
-
-            return modulesList[moduleId];
-        }
-
         private object TouchObject(Type actualType, int refId)
         {
             if(deserializedObjects[refId] != null)
@@ -703,38 +615,12 @@ namespace Antmicro.Migrant
         }
 
         internal bool TreatCollectionAsUserObject { get { return treatCollectionAsUserObject; } }
-
         internal PrimitiveReader PrimitiveReader { get { return reader; } }
+        internal IdentifiedElementsList<ModuleDescriptor> Modules { get; private set; }
+        internal IdentifiedElementsList<AssemblyDescriptor> Assemblies { get; private set; }
+        internal IdentifiedElementsList<MethodDescriptor> Methods { get; private set; }
 
         internal const string LateHookAndSurrogateError = "Type {0}: late post deserialization callback cannot be used in conjunction with surrogates.";
-
-        private static bool CompareGenericArguments(ParameterInfo[] actual, TypeOrGenericTypeArgument[] expected)
-        {
-            if(actual.Length != expected.Length)
-            {
-                return false;
-            }
-
-            for(int i = 0; i < actual.Length; i++)
-            {
-                if(actual[i].ParameterType.IsGenericParameter)
-                {
-                    if(actual[i].ParameterType.GenericParameterPosition != expected[i].GenericTypeArgumentIndex)
-                    {
-                        return false;
-                    }
-                }
-                else
-                {
-                    if(actual[i].ParameterType != expected[i].Type)
-                    {
-                        return false;
-                    }
-                }
-            }
-
-            return true;
-        }
 
         private readonly VersionToleranceLevel versionToleranceLevel;
         private WeakReference[] soFarDeserialized;
@@ -746,9 +632,6 @@ namespace Antmicro.Migrant
         private readonly Dictionary<Type, Func<Int32, object>> delegatesCache;
         private readonly PrimitiveReader reader;
         private readonly Dictionary<int, TypeDescriptor> typeCache;
-        private readonly List<MethodInfo> methodList;
-        private readonly List<AssemblyDescriptor> assembliesList;
-        private readonly List<ModuleDescriptor> modulesList;
         private readonly Action<object> postDeserializationCallback;
         private readonly List<Action> postDeserializationHooks;
         private readonly InheritanceAwareList<Delegate> objectsForSurrogates;

--- a/Migrant/ObjectReader.cs
+++ b/Migrant/ObjectReader.cs
@@ -762,24 +762,6 @@ namespace Antmicro.Migrant
             DefaultCtor,
             Null
         }
-
-        private struct TypeOrGenericTypeArgument
-        {
-            public TypeOrGenericTypeArgument(Type t) : this()
-            {
-                Type = t;
-                GenericTypeArgumentIndex = -1;
-            }
-
-            public TypeOrGenericTypeArgument(int index) : this()
-            {
-                Type = null;
-                GenericTypeArgumentIndex = index;
-            }
-
-            public Type Type { get; private set; }
-            public int GenericTypeArgumentIndex { get; private set; }
-        }
     }
 }
 

--- a/Migrant/ObjectReader.cs
+++ b/Migrant/ObjectReader.cs
@@ -270,7 +270,7 @@ namespace Antmicro.Migrant
 
         private void UpdateFields(Type actualType, object target)
         {
-            var fieldOrTypeInfos = TypeDescriptor.CreateFromType(actualType).FieldsToDeserialize;
+            var fieldOrTypeInfos = ((TypeDescriptor)actualType).FieldsToDeserialize;
             foreach(var fieldOrTypeInfo in fieldOrTypeInfos)
             {
                 if(fieldOrTypeInfo.Field == null)

--- a/Migrant/ObjectReader.cs
+++ b/Migrant/ObjectReader.cs
@@ -565,7 +565,8 @@ namespace Antmicro.Migrant
                 return typeCache[typeId];
             }
 
-            var type = TypeDescriptor.ReadFromStream(this);
+            var type = new TypeDescriptor();
+            type.ReadFromStream(this);
             typeCache.Add(typeId, type);
 
             // we need to read stamp here (i.e., after adding to typeList)

--- a/Migrant/ObjectWriter.cs
+++ b/Migrant/ObjectWriter.cs
@@ -299,7 +299,7 @@ namespace Antmicro.Migrant
 
         internal int TouchAndWriteTypeId(Type type)
         {
-            var typeDescriptor = TypeDescriptor.CreateFromType(type);
+            TypeDescriptor typeDescriptor = type;
 
             int typeId;
             if(typeIndices.ContainsKey(typeDescriptor))

--- a/Migrant/TypeOrGenericTypeArgument.cs
+++ b/Migrant/TypeOrGenericTypeArgument.cs
@@ -1,0 +1,47 @@
+﻿// *******************************************************************
+//
+//  Copyright (c) 2012-2014, Antmicro Ltd <antmicro.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// *******************************************************************
+using System;
+
+namespace Antmicro.Migrant
+{
+    internal struct TypeOrGenericTypeArgument
+    {
+        public TypeOrGenericTypeArgument(Type t) : this()
+        {
+            Type = t;
+            GenericTypeArgumentIndex = -1;
+        }
+
+        public TypeOrGenericTypeArgument(int index) : this()
+        {
+            Type = null;
+            GenericTypeArgumentIndex = index;
+        }
+
+        public Type Type { get; private set; }
+        public int GenericTypeArgumentIndex { get; private set; }
+    }
+}
+

--- a/Migrant/Utilities/IIdentifiedElement.cs
+++ b/Migrant/Utilities/IIdentifiedElement.cs
@@ -28,8 +28,8 @@ namespace Antmicro.Migrant.Utilities
 {
     public interface IIdentifiedElement
     {
-        void ReadFromStream(ObjectReader reader);
-        void WriteTo(ObjectWriter writer);
+        void Read(ObjectReader reader);
+        void Write(ObjectWriter writer);
     }
 }
 

--- a/Migrant/Utilities/IIdentifiedElement.cs
+++ b/Migrant/Utilities/IIdentifiedElement.cs
@@ -1,0 +1,34 @@
+﻿// *******************************************************************
+//
+//  Copyright (c) 2012-2014, Antmicro Ltd <antmicro.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// *******************************************************************
+using System;
+
+namespace Antmicro.Migrant.Utilities
+{
+    public interface IIdentifiedElement
+    {
+        void ReadFromStream(ObjectReader reader);
+    }
+}
+

--- a/Migrant/Utilities/IdentifiedElementsDictionary.cs
+++ b/Migrant/Utilities/IdentifiedElementsDictionary.cs
@@ -22,7 +22,6 @@
 // WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 //
 // *******************************************************************
-using System;
 using System.Collections.Generic;
 
 namespace Antmicro.Migrant.Utilities
@@ -38,9 +37,8 @@ namespace Antmicro.Migrant.Utilities
         public int TouchAndWriteId(T element)
         {
             int typeId;
-            if(dictionary.ContainsKey(element))
+            if(dictionary.TryGetValue(element, out typeId))
             {
-                typeId = dictionary[element];
                 writer.PrimitiveWriter.Write(typeId);
                 return typeId;
             }

--- a/Migrant/Utilities/IdentifiedElementsDictionary.cs
+++ b/Migrant/Utilities/IdentifiedElementsDictionary.cs
@@ -23,13 +23,37 @@
 //
 // *******************************************************************
 using System;
+using System.Collections.Generic;
 
 namespace Antmicro.Migrant.Utilities
 {
-    public interface IIdentifiedElement
+    public class IdentifiedElementsDictionary<T> where T : IIdentifiedElement
     {
-        void ReadFromStream(ObjectReader reader);
-        void WriteTo(ObjectWriter writer);
+        public IdentifiedElementsDictionary(ObjectWriter writer)
+        {
+            this.writer = writer;
+            dictionary = new Dictionary<T, int>();
+        }
+
+        public int TouchAndWriteId(T element)
+        {
+            int typeId;
+            if(dictionary.ContainsKey(element))
+            {
+                typeId = dictionary[element];
+                writer.PrimitiveWriter.Write(typeId);
+                return typeId;
+            }
+            typeId = nextId++;
+            dictionary.Add(element, typeId);
+            writer.PrimitiveWriter.Write(typeId);
+            element.WriteTo(writer);
+            return typeId;
+        }
+
+        private int nextId;
+        private readonly ObjectWriter writer;
+        private readonly Dictionary<T, int> dictionary;
     }
 }
 

--- a/Migrant/Utilities/IdentifiedElementsDictionary.cs
+++ b/Migrant/Utilities/IdentifiedElementsDictionary.cs
@@ -47,7 +47,7 @@ namespace Antmicro.Migrant.Utilities
             typeId = nextId++;
             dictionary.Add(element, typeId);
             writer.PrimitiveWriter.Write(typeId);
-            element.WriteTo(writer);
+            element.Write(writer);
             return typeId;
         }
 

--- a/Migrant/Utilities/IdentifiedElementsList.cs
+++ b/Migrant/Utilities/IdentifiedElementsList.cs
@@ -46,7 +46,7 @@ namespace Antmicro.Migrant.Utilities
             {
                 var element = new T(); 
                 list.Add(element);
-                element.ReadFromStream(reader);
+                element.Read(reader);
                 return element;
             }
 

--- a/Migrant/Utilities/IdentifiedElementsList.cs
+++ b/Migrant/Utilities/IdentifiedElementsList.cs
@@ -1,0 +1,57 @@
+﻿// *******************************************************************
+//
+//  Copyright (c) 2012-2014, Antmicro Ltd <antmicro.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// *******************************************************************
+using System;
+using System.Collections.Generic;
+
+namespace Antmicro.Migrant.Utilities
+{
+    internal class IdentifiedElementsList<T> where T : IIdentifiedElement, new()
+    {
+        public IdentifiedElementsList(ObjectReader reader)
+        {
+            list = new List<T>();
+            this.reader = reader;
+        }
+
+        public T Read()
+        {
+            var id = reader.PrimitiveReader.ReadInt32();
+            if(list.Count <= id)
+            {
+                var element = new T(); 
+                element.ReadFromStream(reader);
+
+                list.Add(element);
+                return element;
+            }
+
+            return list[id];
+        }
+
+        private readonly ObjectReader reader;
+        private readonly List<T> list;
+    }
+}
+

--- a/Migrant/Utilities/IdentifiedElementsList.cs
+++ b/Migrant/Utilities/IdentifiedElementsList.cs
@@ -38,12 +38,15 @@ namespace Antmicro.Migrant.Utilities
         public T Read()
         {
             var id = reader.PrimitiveReader.ReadInt32();
+            if(id == Consts.NullObjectId)
+            {
+                return default(T);
+            }
             if(list.Count <= id)
             {
                 var element = new T(); 
-                element.ReadFromStream(reader);
-
                 list.Add(element);
+                element.ReadFromStream(reader);
                 return element;
             }
 

--- a/Migrant/VersionTolerance/AssemblyDescriptor.cs
+++ b/Migrant/VersionTolerance/AssemblyDescriptor.cs
@@ -50,7 +50,7 @@ namespace Antmicro.Migrant.VersionTolerance
             Token = assembly.GetName().GetPublicKeyToken();
         }
 
-        public void ReadFromStream(ObjectReader reader)
+        public void Read(ObjectReader reader)
         {
             Name = reader.PrimitiveReader.ReadString();
             Version = reader.PrimitiveReader.ReadVersion();
@@ -72,7 +72,7 @@ namespace Antmicro.Migrant.VersionTolerance
             UnderlyingAssembly = Assembly.Load(assemblyName);
         }
 
-        public void WriteTo(ObjectWriter writer)
+        public void Write(ObjectWriter writer)
         {
             writer.PrimitiveWriter.Write(Name);
             writer.PrimitiveWriter.Write(Version);

--- a/Migrant/VersionTolerance/AssemblyDescriptor.cs
+++ b/Migrant/VersionTolerance/AssemblyDescriptor.cs
@@ -26,23 +26,35 @@ using System;
 using System.Reflection;
 using System.Linq;
 using Antmicro.Migrant.Customization;
+using Antmicro.Migrant.Utilities;
 
 namespace Antmicro.Migrant.VersionTolerance
 {
-    internal class AssemblyDescriptor
+    internal class AssemblyDescriptor : IIdentifiedElement
     {
-        public static AssemblyDescriptor ReadFromStream(ObjectReader reader)
+        public AssemblyDescriptor()
         {
-            var descriptor = new AssemblyDescriptor();
-            descriptor.ReadAssemblyStamp(reader);
-            var assemblyName = new AssemblyName(descriptor.FullName);
-            descriptor.UnderlyingAssembly = Assembly.Load(assemblyName);
-            return descriptor;
         }
 
-        public static AssemblyDescriptor CreateFromAssembly(Assembly assembly)
+        public AssemblyDescriptor(Assembly assembly)
         {
-            return new AssemblyDescriptor(assembly);
+            UnderlyingAssembly = assembly;
+
+            Name = assembly.GetName().Name;
+            Version = assembly.GetName().Version;
+            CultureName = assembly.GetName().CultureName;
+            if (CultureName == string.Empty)
+            {
+                CultureName = "neutral";
+            }
+            Token = assembly.GetName().GetPublicKeyToken();
+        }
+
+        public void ReadFromStream(ObjectReader reader)
+        {
+            ReadAssemblyStamp(reader);
+            var assemblyName = new AssemblyName(FullName);
+            UnderlyingAssembly = Assembly.Load(assemblyName);
         }
 
         public void WriteTo(ObjectWriter writer)
@@ -73,24 +85,6 @@ namespace Antmicro.Migrant.VersionTolerance
         public override int GetHashCode()
         {
             return FullName.GetHashCode();
-        }
-
-        private AssemblyDescriptor()
-        {
-        }
-
-        private AssemblyDescriptor(Assembly assembly)
-        {
-            UnderlyingAssembly = assembly;
-
-            Name = assembly.GetName().Name;
-            Version = assembly.GetName().Version;
-            CultureName = assembly.GetName().CultureName;
-            if (CultureName == string.Empty)
-            {
-                CultureName = "neutral";
-            }
-            Token = assembly.GetName().GetPublicKeyToken();
         }
 
         private void WriteAssemblyStamp(ObjectWriter writer)

--- a/Migrant/VersionTolerance/FieldDescriptor.cs
+++ b/Migrant/VersionTolerance/FieldDescriptor.cs
@@ -50,8 +50,8 @@ namespace Antmicro.Migrant
 
         public void WriteTo(ObjectWriter writer)
         {
-            writer.TouchAndWriteTypeId(FieldType.UnderlyingType);
-            writer.TouchAndWriteTypeId(DeclaringType.UnderlyingType);
+            writer.Types.TouchAndWriteId(FieldType.UnderlyingType);
+            writer.Types.TouchAndWriteId(DeclaringType.UnderlyingType);
             writer.PrimitiveWriter.Write(Name);
         }
 

--- a/Migrant/VersionTolerance/FieldDescriptor.cs
+++ b/Migrant/VersionTolerance/FieldDescriptor.cs
@@ -40,8 +40,8 @@ namespace Antmicro.Migrant
         {
             Name = finfo.Name;
 
-            DeclaringType = TypeDescriptor.CreateFromType(finfo.DeclaringType);
-            FieldType = TypeDescriptor.CreateFromType(finfo.FieldType);
+            DeclaringType = finfo.DeclaringType;
+            FieldType = finfo.FieldType;
             IsTransient = finfo.IsTransient();
             IsConstructor = finfo.IsConstructor();
 

--- a/Migrant/VersionTolerance/FieldDescriptor.cs
+++ b/Migrant/VersionTolerance/FieldDescriptor.cs
@@ -57,8 +57,8 @@ namespace Antmicro.Migrant
 
         public void ReadFrom(ObjectReader reader)
         {
-            FieldType = reader.ReadType();
-            DeclaringType = reader.ReadType();
+            FieldType = reader.Types.Read();
+            DeclaringType = reader.Types.Read();
             Name = reader.PrimitiveReader.ReadString();
 
             UnderlyingFieldInfo = DeclaringType.UnderlyingType.GetField(Name, BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic); 

--- a/Migrant/VersionTolerance/MethodDescriptor.cs
+++ b/Migrant/VersionTolerance/MethodDescriptor.cs
@@ -87,13 +87,13 @@ namespace Antmicro.Migrant.VersionTolerance
 
         public void ReadFromStream(ObjectReader reader)
         {
-            var type = reader.ReadType().UnderlyingType;
+            var type = reader.Types.Read().UnderlyingType;
             var methodName = reader.PrimitiveReader.ReadString();
             var genericArgumentsCount = reader.PrimitiveReader.ReadInt32();
             var genericArguments = new Type[genericArgumentsCount];
             for(int i = 0; i < genericArgumentsCount; i++)
             {
-                genericArguments[i] = reader.ReadType().UnderlyingType;
+                genericArguments[i] = reader.Types.Read().UnderlyingType;
             }
 
             var parametersCount = reader.PrimitiveReader.ReadInt32();
@@ -105,7 +105,7 @@ namespace Antmicro.Migrant.VersionTolerance
                     var genericType = reader.PrimitiveReader.ReadBoolean();
                     parameters[i] = genericType ? 
                         new TypeOrGenericTypeArgument(reader.PrimitiveReader.ReadInt32()) :
-                        new TypeOrGenericTypeArgument(reader.ReadType().UnderlyingType);
+                        new TypeOrGenericTypeArgument(reader.Types.Read().UnderlyingType);
                 }
 
                 UnderlyingMethod = type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic).SingleOrDefault(m => 
@@ -124,7 +124,7 @@ namespace Antmicro.Migrant.VersionTolerance
                 var types = new Type[parametersCount];
                 for(int i = 0; i < types.Length; i++)
                 {
-                    types[i] = reader.ReadType().UnderlyingType;
+                    types[i] = reader.Types.Read().UnderlyingType;
                 }
 
                 UnderlyingMethod = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, types, null);

--- a/Migrant/VersionTolerance/MethodDescriptor.cs
+++ b/Migrant/VersionTolerance/MethodDescriptor.cs
@@ -1,0 +1,115 @@
+﻿// *******************************************************************
+//
+//  Copyright (c) 2012-2014, Antmicro Ltd <antmicro.com>
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+//
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+// *******************************************************************
+using System;
+using Antmicro.Migrant.Utilities;
+using System.Reflection;
+using System.Linq;
+
+namespace Antmicro.Migrant.VersionTolerance
+{
+    internal class MethodDescriptor : IIdentifiedElement
+    {
+        public MethodDescriptor()
+        {
+        }
+
+        public void ReadFromStream(ObjectReader reader)
+        {
+            var type = reader.ReadType().UnderlyingType;
+            var methodName = reader.PrimitiveReader.ReadString();
+            var genericArgumentsCount = reader.PrimitiveReader.ReadInt32();
+            var genericArguments = new Type[genericArgumentsCount];
+            for(int i = 0; i < genericArgumentsCount; i++)
+            {
+                genericArguments[i] = reader.ReadType().UnderlyingType;
+            }
+
+            var parametersCount = reader.PrimitiveReader.ReadInt32();
+            if(genericArgumentsCount > 0)
+            {
+                var parameters = new TypeOrGenericTypeArgument[parametersCount];
+                for(int i = 0; i < parameters.Length; i++)
+                {
+                    var genericType = reader.PrimitiveReader.ReadBoolean();
+                    parameters[i] = genericType ? 
+                        new TypeOrGenericTypeArgument(reader.PrimitiveReader.ReadInt32()) :
+                        new TypeOrGenericTypeArgument(reader.ReadType().UnderlyingType);
+                }
+
+                UnderlyingMethod = type.GetMethods(BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic).SingleOrDefault(m => 
+                    m.IsGenericMethod && 
+                    m.GetGenericMethodDefinition().Name == methodName && 
+                    m.GetGenericArguments().Length == genericArgumentsCount && 
+                    CompareGenericArguments(m.GetGenericMethodDefinition().GetParameters(), parameters));
+
+                if(UnderlyingMethod != null)
+                {
+                    UnderlyingMethod = UnderlyingMethod.MakeGenericMethod(genericArguments);
+                }
+            }
+            else
+            {
+                var types = new Type[parametersCount];
+                for(int i = 0; i < types.Length; i++)
+                {
+                    types[i] = reader.ReadType().UnderlyingType;
+                }
+
+                UnderlyingMethod = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic, null, types, null);
+            }
+        }
+
+        public MethodInfo UnderlyingMethod { get; private set; }
+
+        private static bool CompareGenericArguments(ParameterInfo[] actual, TypeOrGenericTypeArgument[] expected)
+        {
+            if(actual.Length != expected.Length)
+            {
+                return false;
+            }
+
+            for(int i = 0; i < actual.Length; i++)
+            {
+                if(actual[i].ParameterType.IsGenericParameter)
+                {
+                    if(actual[i].ParameterType.GenericParameterPosition != expected[i].GenericTypeArgumentIndex)
+                    {
+                        return false;
+                    }
+                }
+                else
+                {
+                    if(actual[i].ParameterType != expected[i].Type)
+                    {
+                        return false;
+                    }
+                }
+            }
+
+            return true;
+        }
+    }
+}
+

--- a/Migrant/VersionTolerance/MethodDescriptor.cs
+++ b/Migrant/VersionTolerance/MethodDescriptor.cs
@@ -35,6 +35,10 @@ namespace Antmicro.Migrant.VersionTolerance
         {
         }
 
+        public void WriteTo(ObjectWriter writer)
+        {
+        }
+
         public void ReadFromStream(ObjectReader reader)
         {
             var type = reader.ReadType().UnderlyingType;

--- a/Migrant/VersionTolerance/MethodDescriptor.cs
+++ b/Migrant/VersionTolerance/MethodDescriptor.cs
@@ -40,7 +40,7 @@ namespace Antmicro.Migrant.VersionTolerance
             UnderlyingMethod = method;
         }
 
-        public void WriteTo(ObjectWriter writer)
+        public void Write(ObjectWriter writer)
         {
             writer.Types.TouchAndWriteId(UnderlyingMethod.ReflectedType);
 
@@ -85,7 +85,7 @@ namespace Antmicro.Migrant.VersionTolerance
             }
         }
 
-        public void ReadFromStream(ObjectReader reader)
+        public void Read(ObjectReader reader)
         {
             var type = reader.Types.Read().UnderlyingType;
             var methodName = reader.PrimitiveReader.ReadString();

--- a/Migrant/VersionTolerance/ModuleDescriptor.cs
+++ b/Migrant/VersionTolerance/ModuleDescriptor.cs
@@ -51,7 +51,7 @@ namespace Antmicro.Migrant.VersionTolerance
 
         public void WriteTo(ObjectWriter writer)
         {
-            writer.TouchAndWriteAssemblyId(ModuleAssembly);
+            writer.Assemblies.TouchAndWriteId(ModuleAssembly);
             writer.PrimitiveWriter.Write(GUID);
             writer.PrimitiveWriter.Write(Name);
         }

--- a/Migrant/VersionTolerance/ModuleDescriptor.cs
+++ b/Migrant/VersionTolerance/ModuleDescriptor.cs
@@ -42,14 +42,14 @@ namespace Antmicro.Migrant.VersionTolerance
             GUID = module.ModuleVersionId;
         }
 
-        public void ReadFromStream(ObjectReader reader)
+        public void Read(ObjectReader reader)
         {
             ModuleAssembly = reader.Assemblies.Read();
             GUID = reader.PrimitiveReader.ReadGuid();
             Name = reader.PrimitiveReader.ReadString();
         }
 
-        public void WriteTo(ObjectWriter writer)
+        public void Write(ObjectWriter writer)
         {
             writer.Assemblies.TouchAndWriteId(ModuleAssembly);
             writer.PrimitiveWriter.Write(GUID);

--- a/Migrant/VersionTolerance/ModuleDescriptor.cs
+++ b/Migrant/VersionTolerance/ModuleDescriptor.cs
@@ -44,17 +44,12 @@ namespace Antmicro.Migrant.VersionTolerance
 
         public void ReadFromStream(ObjectReader reader)
         {
-            ReadModuleStamp(reader);
-        }
-
-        public void ReadModuleStamp(ObjectReader reader)
-        {
             ModuleAssembly = reader.Assemblies.Read();
             GUID = reader.PrimitiveReader.ReadGuid();
             Name = reader.PrimitiveReader.ReadString();
         }
 
-        public void WriteModuleStamp(ObjectWriter writer)
+        public void WriteTo(ObjectWriter writer)
         {
             writer.TouchAndWriteAssemblyId(ModuleAssembly);
             writer.PrimitiveWriter.Write(GUID);

--- a/Migrant/VersionTolerance/ModuleDescriptor.cs
+++ b/Migrant/VersionTolerance/ModuleDescriptor.cs
@@ -25,26 +25,31 @@
 using System;
 using System.Reflection;
 using Antmicro.Migrant.Customization;
+using Antmicro.Migrant.Utilities;
 
 namespace Antmicro.Migrant.VersionTolerance
 {
-    internal class ModuleDescriptor
+    internal class ModuleDescriptor : IIdentifiedElement
     {
-        public static ModuleDescriptor CreateFromModule(Module module)
+        public ModuleDescriptor()
         {
-            return new ModuleDescriptor(module);
         }
 
-        public static ModuleDescriptor ReadFromStream(ObjectReader reader)
+        public ModuleDescriptor(Module module)
         {
-            var module = new ModuleDescriptor();
-            module.ReadModuleStamp(reader);
-            return module;
+            ModuleAssembly = new AssemblyDescriptor(module.Assembly);
+            Name = module.Name;
+            GUID = module.ModuleVersionId;
+        }
+
+        public void ReadFromStream(ObjectReader reader)
+        {
+            ReadModuleStamp(reader);
         }
 
         public void ReadModuleStamp(ObjectReader reader)
         {
-            ModuleAssembly = reader.ReadAssembly();
+            ModuleAssembly = reader.Assemblies.Read();
             GUID = reader.PrimitiveReader.ReadGuid();
             Name = reader.PrimitiveReader.ReadString();
         }
@@ -63,17 +68,6 @@ namespace Antmicro.Migrant.VersionTolerance
                 return obj != null && obj.Name == Name && ModuleAssembly.Equals(obj.ModuleAssembly, versionToleranceLevel);
             }
             return obj != null && obj.GUID == GUID && ModuleAssembly.Equals(obj.ModuleAssembly, versionToleranceLevel);
-        }
-        
-        private ModuleDescriptor()
-        {
-        }
-
-        private ModuleDescriptor(Module module)
-        {
-            ModuleAssembly = AssemblyDescriptor.CreateFromAssembly(module.Assembly);
-            Name = module.Name;
-            GUID = module.ModuleVersionId;
         }
 
         public string Name { get; private set; }

--- a/Migrant/VersionTolerance/TypeDescriptor.cs
+++ b/Migrant/VersionTolerance/TypeDescriptor.cs
@@ -93,12 +93,12 @@ namespace Antmicro.Migrant
 
         public void WriteTypeStamp(ObjectWriter writer)
         {
-            writer.TouchAndWriteModuleId(TypeModule);
+            writer.Modules.TouchAndWriteId(TypeModule);
             writer.PrimitiveWriter.Write(GenericFullName);
             writer.PrimitiveWriter.Write(genericArguments.Count);
             foreach (var genericArgument in genericArguments)
             {
-                writer.TouchAndWriteTypeId(genericArgument.UnderlyingType);
+                writer.Types.TouchAndWriteId(genericArgument.UnderlyingType);
             }
         }
 
@@ -329,7 +329,7 @@ namespace Antmicro.Migrant
             }
             else
             {
-                writer.TouchAndWriteTypeId(baseType.UnderlyingType);
+                writer.Types.TouchAndWriteId(baseType.UnderlyingType);
             }
 
             writer.PrimitiveWriter.Write(fields.Count);

--- a/Migrant/VersionTolerance/TypeDescriptor.cs
+++ b/Migrant/VersionTolerance/TypeDescriptor.cs
@@ -64,9 +64,11 @@ namespace Antmicro.Migrant
             genericArguments = new List<TypeDescriptor>();
             for(int i = 0; i < genericArgumentsCount; i++)
             {
-                genericArguments.Add(reader.ReadType());
+                genericArguments.Add(reader.Types.Read());
             }
+
             Resolve();
+            ReadStructureStampIfNeeded(reader, reader.VersionToleranceLevel);
         }
 
         public void WriteTo(ObjectWriter writer)
@@ -309,7 +311,7 @@ namespace Antmicro.Migrant
 
         private void ReadStructureStamp(ObjectReader reader, VersionToleranceLevel versionToleranceLevel)
         {
-            baseType = reader.ReadType();
+            baseType = reader.Types.Read();
             var noOfFields = reader.PrimitiveReader.ReadInt32();
             for(int i = 0; i < noOfFields; i++)
             {

--- a/Migrant/VersionTolerance/TypeDescriptor.cs
+++ b/Migrant/VersionTolerance/TypeDescriptor.cs
@@ -41,7 +41,7 @@ namespace Antmicro.Migrant
             return result;
         }
 
-        public static TypeDescriptor CreateFromType(Type type)
+        public static implicit operator TypeDescriptor(Type type)
         {
             TypeDescriptor value;
             if(!cache.TryGetValue(type, out value))
@@ -175,7 +175,7 @@ namespace Antmicro.Migrant
                 GenericAssemblyQualifiedName = UnderlyingType.GetGenericTypeDefinition().AssemblyQualifiedName;
                 foreach(var genericArgument in UnderlyingType.GetGenericArguments())
                 {
-                    genericArguments.Add(TypeDescriptor.CreateFromType(genericArgument));
+                    genericArguments.Add(genericArgument);
                 }
             }
             else
@@ -186,7 +186,7 @@ namespace Antmicro.Migrant
 
             if(t.BaseType != null)
             {
-                baseType = TypeDescriptor.CreateFromType(t.BaseType);
+                baseType = t.BaseType;
             }
 
             var fieldsToDeserialize = new List<FieldInfoOrEntryToOmit>();
@@ -245,7 +245,7 @@ namespace Antmicro.Migrant
 
             var result = new List<FieldInfoOrEntryToOmit>();
 
-            var assemblyTypeDescriptor = TypeDescriptor.CreateFromType(UnderlyingType);
+            var assemblyTypeDescriptor = ((TypeDescriptor)UnderlyingType);
             if( !(assemblyTypeDescriptor.baseType == null && baseType == null)
                 && ((assemblyTypeDescriptor.baseType == null && baseType != null) || !assemblyTypeDescriptor.baseType.Equals(baseType)) 
                 && !versionToleranceLevel.HasFlag(VersionToleranceLevel.AllowInheritanceChainChange))

--- a/Migrant/VersionTolerance/TypeDescriptor.cs
+++ b/Migrant/VersionTolerance/TypeDescriptor.cs
@@ -166,7 +166,7 @@ namespace Antmicro.Migrant
         {
             UnderlyingType = t;
 
-            TypeModule = ModuleDescriptor.CreateFromModule(t.Module);
+            TypeModule = new ModuleDescriptor(t.Module);
 
             genericArguments = new List<TypeDescriptor>();
             if(UnderlyingType.IsGenericType)
@@ -296,7 +296,7 @@ namespace Antmicro.Migrant
 
         private void ReadTypeStamp(ObjectReader reader)
         {
-            TypeModule = reader.ReadModule();
+            TypeModule = reader.Modules.Read();
             GenericFullName = reader.PrimitiveReader.ReadString();
             var genericArgumentsCount = reader.PrimitiveReader.ReadInt32();
             genericArguments = new List<TypeDescriptor>();

--- a/Migrant/VersionTolerance/TypeDescriptor.cs
+++ b/Migrant/VersionTolerance/TypeDescriptor.cs
@@ -56,7 +56,7 @@ namespace Antmicro.Migrant
             fields = new List<FieldDescriptor>();
         }
 
-        public void ReadFromStream(ObjectReader reader)
+        public void Read(ObjectReader reader)
         {
             TypeModule = reader.Modules.Read();
             GenericFullName = reader.PrimitiveReader.ReadString();
@@ -71,7 +71,7 @@ namespace Antmicro.Migrant
             ReadStructureStampIfNeeded(reader, reader.VersionToleranceLevel);
         }
 
-        public void WriteTo(ObjectWriter writer)
+        public void Write(ObjectWriter writer)
         {
             WriteTypeStamp(writer);
             WriteStructureStampIfNeeded(writer);

--- a/Tests/TypeDescriptorComparisonTests.cs
+++ b/Tests/TypeDescriptorComparisonTests.cs
@@ -42,7 +42,7 @@ namespace Antmicro.Migrant.Tests
         public void ShouldFindNoDifferences()
         {
             var obj = DynamicType.CreateClass("C", DynamicType.CreateClass("B", DynamicType.CreateClass("A"))).Instantiate();
-            var typeDescriptor = TypeDescriptor.CreateFromType(obj.GetType());
+            var typeDescriptor = ((TypeDescriptor)obj.GetType());
 
             var compareResult = typeDescriptor.CompareWith(typeDescriptor);
             Assert.IsTrue(compareResult.Empty);
@@ -54,8 +54,8 @@ namespace Antmicro.Migrant.Tests
             var objPrev = DynamicType.CreateClass("A").Instantiate();
             var objCurr = DynamicType.CreateClass("A").WithField("a", typeof(int)).Instantiate();
 
-            var descPrev = TypeDescriptor.CreateFromType(objPrev.GetType());
-            var descCurr = TypeDescriptor.CreateFromType(objCurr.GetType());
+            var descPrev = ((TypeDescriptor)objPrev.GetType());
+            var descCurr = ((TypeDescriptor)objCurr.GetType());
 
             var compareResult = descCurr.CompareWith(descPrev);
 
@@ -72,8 +72,8 @@ namespace Antmicro.Migrant.Tests
             var objPrev = DynamicType.CreateClass("A").Instantiate();
             var objCurr = DynamicType.CreateClass("A").WithTransientField("a", typeof(int)).Instantiate();
 
-            var descPrev = TypeDescriptor.CreateFromType(objPrev.GetType());
-            var descCurr = TypeDescriptor.CreateFromType(objCurr.GetType());
+            var descPrev = ((TypeDescriptor)objPrev.GetType());
+            var descCurr = ((TypeDescriptor)objCurr.GetType());
 
             var compareResult = descCurr.CompareWith(descPrev);
 
@@ -86,8 +86,8 @@ namespace Antmicro.Migrant.Tests
             var objPrev = DynamicType.CreateClass("A", DynamicType.CreateClass("Base").WithField("a", typeof(int))).Instantiate();
             var objCurr = DynamicType.CreateClass("A", DynamicType.CreateClass("Base").WithField("a", typeof(int))).WithField("a", typeof(int)).Instantiate();
 
-            var descPrev = TypeDescriptor.CreateFromType(objPrev.GetType());
-            var descCurr = TypeDescriptor.CreateFromType(objCurr.GetType());
+            var descPrev = ((TypeDescriptor)objPrev.GetType());
+            var descCurr = ((TypeDescriptor)objCurr.GetType());
 
             var compareResult = descCurr.CompareWith(descPrev);
 
@@ -104,8 +104,8 @@ namespace Antmicro.Migrant.Tests
             var objPrev = DynamicType.CreateClass("A").WithField("a", typeof(int)).Instantiate();
             var objCurr = DynamicType.CreateClass("A").Instantiate();
 
-            var descPrev = TypeDescriptor.CreateFromType(objPrev.GetType());
-            var descCurr = TypeDescriptor.CreateFromType(objCurr.GetType());
+            var descPrev = ((TypeDescriptor)objPrev.GetType());
+            var descCurr = ((TypeDescriptor)objCurr.GetType());
 
             var compareResult = descCurr.CompareWith(descPrev);
 
@@ -122,8 +122,8 @@ namespace Antmicro.Migrant.Tests
             var objPrev = DynamicType.CreateClass("A").WithTransientField("a", typeof(int)).Instantiate();
             var objCurr = DynamicType.CreateClass("A").Instantiate();
 
-            var descPrev = TypeDescriptor.CreateFromType(objPrev.GetType());
-            var descCurr = TypeDescriptor.CreateFromType(objCurr.GetType());
+            var descPrev = ((TypeDescriptor)objPrev.GetType());
+            var descCurr = ((TypeDescriptor)objCurr.GetType());
 
             var compareResult = descCurr.CompareWith(descPrev);
 
@@ -136,8 +136,8 @@ namespace Antmicro.Migrant.Tests
             var objPrev = DynamicType.CreateClass("A", DynamicType.CreateClass("Base").WithField("a", typeof(int))).WithField("a", typeof(int)).Instantiate();
             var objCurr = DynamicType.CreateClass("A", DynamicType.CreateClass("Base").WithField("a", typeof(int))).Instantiate();
 
-            var descPrev = TypeDescriptor.CreateFromType(objPrev.GetType());
-            var descCurr = TypeDescriptor.CreateFromType(objCurr.GetType());
+            var descPrev = ((TypeDescriptor)objPrev.GetType());
+            var descCurr = ((TypeDescriptor)objCurr.GetType());
 
             var compareResult = descCurr.CompareWith(descPrev);
 
@@ -154,8 +154,8 @@ namespace Antmicro.Migrant.Tests
             var objPrev = DynamicType.CreateClass("A", DynamicType.CreateClass("Base")).WithField("a", typeof(int)).Instantiate();
             var objCurr = DynamicType.CreateClass("A", DynamicType.CreateClass("Base").WithField("a", typeof(int))).Instantiate();
 
-            var descPrev = TypeDescriptor.CreateFromType(objPrev.GetType());
-            var descCurr = TypeDescriptor.CreateFromType(objCurr.GetType());
+            var descPrev = ((TypeDescriptor)objPrev.GetType());
+            var descCurr = ((TypeDescriptor)objCurr.GetType());
 
             var compareResult = descCurr.CompareWith(descPrev);
 
@@ -173,8 +173,8 @@ namespace Antmicro.Migrant.Tests
             var objPrev = DynamicType.CreateClass("A", DynamicType.CreateClass("Base")).WithField("a", typeof(int)).Instantiate();
             var objCurr = DynamicType.CreateClass("A", DynamicType.CreateClass("Base").WithField("a", typeof(int))).Instantiate();
 
-            var descPrev = TypeDescriptor.CreateFromType(objPrev.GetType());
-            var descCurr = TypeDescriptor.CreateFromType(objCurr.GetType());
+            var descPrev = ((TypeDescriptor)objPrev.GetType());
+            var descCurr = ((TypeDescriptor)objCurr.GetType());
 
             var compareResult = descCurr.CompareWith(descPrev);
 
@@ -192,8 +192,8 @@ namespace Antmicro.Migrant.Tests
             var objPrev = DynamicType.CreateClass("A").WithField("a", typeof(int)).Instantiate();
             var objCurr = DynamicType.CreateClass("A").WithField("a", typeof(long)).Instantiate();
 
-            var descPrev = TypeDescriptor.CreateFromType(objPrev.GetType());
-            var descCurr = TypeDescriptor.CreateFromType(objCurr.GetType());
+            var descPrev = ((TypeDescriptor)objPrev.GetType());
+            var descCurr = ((TypeDescriptor)objCurr.GetType());
 
             var compareResult = descCurr.CompareWith(descPrev);
 
@@ -210,8 +210,8 @@ namespace Antmicro.Migrant.Tests
             var objPrev = DynamicType.CreateClass("A").WithField("a", DynamicType.CreateClass("C").WithField<int>("c")).Instantiate(new Version(1, 0));
             var objCurr = DynamicType.CreateClass("A").WithField("a", DynamicType.CreateClass("C").WithField<int>("c")).Instantiate(new Version(1, 1));
 
-            var descPrev = TypeDescriptor.CreateFromType(objPrev.GetType());
-            var descCurr = TypeDescriptor.CreateFromType(objCurr.GetType());
+            var descPrev = ((TypeDescriptor)objPrev.GetType());
+            var descCurr = ((TypeDescriptor)objCurr.GetType());
 
             var compareResult = descCurr.CompareWith(descPrev, VersionToleranceLevel.AllowAssemblyVersionChange);
 


### PR DESCRIPTION
After adding support for assemblies with multiple modules there is a lot of very similar code in `ObjectReader` and `ObjectWriter` classes that handles lists of
modules/types/methods/assemblies. In order to simplify this architecture I propose a generic class that allows to reduce amount of CCCV.

During unification of interfaces it turned out that `MethodInfo` classes were handled a bit differently than rest, so I decided to introduce `MethodDescriptor` class to make it all consistent.