### PR TITLE
Performance optimizations issue92

### DIFF
--- a/Migrant/Helpers.cs
+++ b/Migrant/Helpers.cs
@@ -26,6 +26,7 @@
   WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
@@ -203,9 +204,10 @@ namespace Antmicro.Migrant
             return TypesWriteableByPrimitiveWriter.Contains(type);
         }
 
+        private static readonly ConcurrentDictionary<Type, bool> lookup = new ConcurrentDictionary<Type, bool>();  
         internal static bool CheckTransientNoCache(Type type)
         {
-            return type.IsDefined(typeof(TransientAttribute), true);
+            return lookup.GetOrAdd(type, t => t.IsDefined(typeof(TransientAttribute), true));
         }
 
         internal static SerializationType GetSerializationType(Type type)

--- a/Migrant/Helpers.cs
+++ b/Migrant/Helpers.cs
@@ -204,10 +204,10 @@ namespace Antmicro.Migrant
             return TypesWriteableByPrimitiveWriter.Contains(type);
         }
 
-        private static readonly ConcurrentDictionary<Type, bool> lookup = new ConcurrentDictionary<Type, bool>();  
+        private static readonly ConcurrentDictionary<Type, bool> AttrbuteIsDefinedLookup = new ConcurrentDictionary<Type, bool>();  
         internal static bool CheckTransientNoCache(Type type)
         {
-            return lookup.GetOrAdd(type, t => t.IsDefined(typeof(TransientAttribute), true));
+            return AttrbuteIsDefinedLookup.GetOrAdd(type, t => t.IsDefined(typeof(TransientAttribute), true));
         }
 
         internal static SerializationType GetSerializationType(Type type)

--- a/Migrant/ObjectWriter.cs
+++ b/Migrant/ObjectWriter.cs
@@ -40,6 +40,7 @@ using Antmicro.Migrant.VersionTolerance;
 using Antmicro.Migrant.Utilities;
 using Antmicro.Migrant.Customization;
 using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
 
 namespace Antmicro.Migrant
 {
@@ -302,9 +303,8 @@ namespace Antmicro.Migrant
             var typeDescriptor = TypeDescriptor.CreateFromType(type);
 
             int typeId;
-            if(typeIndices.ContainsKey(typeDescriptor))
+            if (typeIndices.TryGetValue(typeDescriptor, out typeId))
             {
-                typeId = typeIndices[typeDescriptor];
                 writer.Write(typeId);
                 return typeId;
             }
@@ -319,9 +319,8 @@ namespace Antmicro.Migrant
         internal int TouchAndWriteAssemblyId(AssemblyDescriptor assembly)
         {
             int assemblyId;
-            if(assemblyIndices.ContainsKey(assembly))
+            if (assemblyIndices.TryGetValue(assembly, out assemblyId))
             {
-                assemblyId = assemblyIndices[assembly];
                 writer.Write(assemblyId);
                 return assemblyId;
             }

--- a/Migrant/ObjectWriter.cs
+++ b/Migrant/ObjectWriter.cs
@@ -25,22 +25,21 @@
   OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
   WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
+
 using System;
-using System.IO;
+using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
-using System.Collections;
-using Antmicro.Migrant.Hooks;
-using Antmicro.Migrant.Generators;
 using System.Reflection.Emit;
 using System.Threading;
-using System.Diagnostics;
-using Antmicro.Migrant.VersionTolerance;
-using Antmicro.Migrant.Utilities;
 using Antmicro.Migrant.Customization;
-using System.Runtime.CompilerServices;
-using System.Runtime.InteropServices;
+using Antmicro.Migrant.Generators;
+using Antmicro.Migrant.Hooks;
+using Antmicro.Migrant.Utilities;
+using Antmicro.Migrant.VersionTolerance;
 
 namespace Antmicro.Migrant
 {

--- a/Migrant/VersionTolerance/AssemblyDescriptor.cs
+++ b/Migrant/VersionTolerance/AssemblyDescriptor.cs
@@ -40,6 +40,8 @@ namespace Antmicro.Migrant.VersionTolerance
             return descriptor;
         }
 
+        public int? AssemblyId { get; set; }
+
         public static AssemblyDescriptor CreateFromAssembly(Assembly assembly)
         {
             return new AssemblyDescriptor(assembly);
@@ -132,7 +134,22 @@ namespace Antmicro.Migrant.VersionTolerance
             ModuleGUID = reader.PrimitiveReader.ReadGuid();
         }
 
-        public string FullName { get { return string.Format("{0}, Version={1}, Culture={2}, PublicKeyToken={3}", Name, Version, CultureName, Token.Length == 0 ? "null" : String.Join(string.Empty, Token.Select(x => string.Format("{0:x2}", x)))); } }
+        private string _fullName;
+        public string FullName
+        {
+            get
+            {
+                if (_fullName == null)
+                {
+                    _fullName = string.Format("{0}, Version={1}, Culture={2}, PublicKeyToken={3}", Name, Version, CultureName,
+                   Token.Length == 0
+                       ? "null"
+                       : String.Join(string.Empty, Token.Select(x => string.Format("{0:x2}", x))));
+                }
+
+                return _fullName;
+            }
+        }
 
         public Guid ModuleGUID { get; private set; } 
         public Assembly UnderlyingAssembly { get; private set; }

--- a/Migrant/VersionTolerance/AssemblyDescriptor.cs
+++ b/Migrant/VersionTolerance/AssemblyDescriptor.cs
@@ -40,8 +40,6 @@ namespace Antmicro.Migrant.VersionTolerance
             return descriptor;
         }
 
-        public int? AssemblyId { get; set; }
-
         public static AssemblyDescriptor CreateFromAssembly(Assembly assembly)
         {
             return new AssemblyDescriptor(assembly);


### PR DESCRIPTION
This PR addresses some performance issues. related to #92 

* Equality comparison for AssemblyDescriptor was based on string join and linq select, effectively recomputing the assembly `FullName` property on each comparison, extremely expensive when combined with dictionaries/hash based lookups
* Some usages of ContainsKey + Indexer lookup for dictionaries have been replaced with `TryGetValue` as this only does one hash lookup instead of two.
* `CheckTransientNoCache` used `IsDefined` to lookup the precense of an attribute, this is expensive and is replaced with a concurrent lookup table. my assumption is that a type never change their set of attributes  during runtime and that this would be safe. 

I know that the way we plan to use Migrant in Akka.NET is suboptimal as we must serialize individual objects one at a time (heritage from how Akka on the JVM was designed) 
This PR brings a 7-8 times performance improvement during these conditions.
